### PR TITLE
Remove unused signup example generator

### DIFF
--- a/src/app/login/actions.ts
+++ b/src/app/login/actions.ts
@@ -46,7 +46,3 @@ export async function signup(formData: FormData) {
   revalidatePath('/admin', 'layout')
   redirect('/admin')
 }
-
-export async function generateExampleData(user_uid: string) {
-  const supabase = createClient()
-}


### PR DESCRIPTION
## Summary
- delete the `generateExampleData` stub in login actions

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849e6efa000832e9adbeb7b6414683d