### PR TITLE
Remove dangling order detail link

### DIFF
--- a/src/app/admin/orders/page.tsx
+++ b/src/app/admin/orders/page.tsx
@@ -14,7 +14,6 @@ import {
   SearchIcon,
   FilterIcon,
   FilePenIcon,
-  EyeIcon,
 } from "lucide-react";
 import {
   Table,
@@ -49,7 +48,6 @@ import {
   DropdownMenuSeparator,
   DropdownMenuCheckboxItem,
 } from "@/components/ui/dropdown-menu";
-import Link from "next/link";
 
 type Order = {
   id: number;
@@ -332,12 +330,6 @@ export default function OrdersPage() {
                         <Trash2 className="w-4 h-4" />
                         <span className="sr-only">Delete</span>
                       </Button>
-                      <Link href={`/admin/orders/${order.id}`} prefetch={false}>
-                        <Button size="icon" variant="ghost">
-                          <EyeIcon className="w-4 h-4" />
-                          <span className="sr-only">View</span>
-                        </Button>
-                      </Link>
                     </div>
                   </TableCell>
                 </TableRow>


### PR DESCRIPTION
## Summary
- clean up unused EyeIcon import and Link in admin orders page

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6849e6f13d44832eaf2affb663958147